### PR TITLE
Revert "Correct swapped pin numbers on DAT2/3."

### DIFF
--- a/Hardware/MicroMod-Teensy.brd
+++ b/Hardware/MicroMod-Teensy.brd
@@ -4725,7 +4725,7 @@ Out</text>
 <wire x1="3.3138625" y1="8.0911375" x2="3.015" y2="8.39" width="0.1016" layer="15"/>
 <wire x1="8.65" y1="8.34" x2="8.4011375" y2="8.0911375" width="0.1016" layer="15"/>
 </signal>
-<signal name="38/DAT3">
+<signal name="39/DAT3">
 <contactref element="J1" pad="70"/>
 <contactref element="U1" pad="J2"/>
 <wire x1="8.975" y1="7.415" x2="8.67535" y2="7.11535" width="0.1016" layer="1"/>
@@ -6442,7 +6442,7 @@ Out</text>
 <wire x1="9.354290625" y1="10.370290625" x2="7.960209375" y2="10.370290625" width="0.1016" layer="15"/>
 <wire x1="11.3238875" y1="10.0114" x2="10.1179125" y2="10.0114" width="0.1016" layer="15"/>
 </signal>
-<signal name="39/DAT2">
+<signal name="38/DAT2">
 <contactref element="U1" pad="H2"/>
 <contactref element="J1" pad="68"/>
 <wire x1="8.325" y1="7.415" x2="8.325" y2="7.1459875" width="0.1016" layer="1"/>

--- a/Hardware/MicroMod-Teensy.sch
+++ b/Hardware/MicroMod-Teensy.sch
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="9.6.2">
+<eagle version="9.6.0">
 <drawing>
 <settings>
 <setting alwaysvectorfont="yes"/>
@@ -20793,7 +20793,7 @@ battery or external power</text>
 <pinref part="J1" gate="J1" pin="SPI_SDO1/SDIO_CMD"/>
 </segment>
 </net>
-<net name="38/DAT3" class="0">
+<net name="39/DAT3" class="0">
 <segment>
 <wire x1="297.18" y1="241.3" x2="299.72" y2="241.3" width="0.1524" layer="91"/>
 <label x="299.72" y="241.3" size="1.27" layer="95" xref="yes"/>
@@ -21908,7 +21908,7 @@ battery or external power</text>
 <label x="398.78" y="218.44" size="1.27" layer="95" xref="yes"/>
 </segment>
 </net>
-<net name="39/DAT2" class="0">
+<net name="38/DAT2" class="0">
 <segment>
 <wire x1="162.56" y1="93.98" x2="165.1" y2="93.98" width="0.1524" layer="91"/>
 <pinref part="U1" gate="U1" pin="SD_B0_04"/>


### PR DESCRIPTION
This reverts commit 18efc8621dbd46baebb258ee20b759296ca70ac1.

I think the schematic may have been originally correct and the [pin swap issue](https://forum.pjrc.com/threads/60260-Error-in-Teensy-4-0-circuit-diagram-(-)) only needed to be fixed in the Arduino core: [PaulStoffregen/cores@17f6526](https://github.com/PaulStoffregen/cores/commit/17f652645c1af3bb0190d6b3769d48358c7ad276)

* Pin Swap Issue:
  ![image](https://github.com/sparkfun/MicroMod_Teensy_Processor/assets/36016723/4732cb63-8262-46c8-927c-5fa6e2be9751)
* Datasheet: [IMXRT1060 Manual, Rev 3](https://www.pjrc.com/teensy/IMXRT1060RM_rev3.pdf) for Teensy 4.0 & 4.1
  * From Table 10-1 Muxing Options (pg. 313)
    ![image](https://github.com/sparkfun/MicroMod_Teensy_Processor/assets/36016723/c25fb95d-443b-4336-841d-695f129b7c01)
  * `SD_B0_04` --> `DAT2`
  * `SD_B0_05` --> `DAT3`
* Fixed in Arduino core:
  ![image](https://github.com/sparkfun/MicroMod_Teensy_Processor/assets/36016723/a04109a7-3aab-4e8b-b90a-d1150b3c39d1)
  * Defines: `PIN38` = `SD_B0_04`
  * Defines: `PIN39` = `SD_B0_05`

Processor Board Schematic:
* Commit 18efc8621dbd46baebb258ee20b759296ca70ac1:
  ![image](https://github.com/sparkfun/MicroMod_Teensy_Processor/assets/36016723/0a392920-ba42-4cc6-a48c-cf9a2725c5c8)
  * `SD_B0_04` --> `PIN39`❌ & `DAT2`
  * `SD_B0_05` --> `PIN38`❌ & `DAT3`
* Previously:
  ![image](https://github.com/sparkfun/MicroMod_Teensy_Processor/assets/36016723/7c9bd120-b766-4624-9e40-5f321b146e7d)
  * `SD_B0_04` --> `PIN38`✅ & `DAT2`
  * `SD_B0_05` --> `PIN39`✅ & `DAT3`
